### PR TITLE
Add Dockerfile to build binaries

### DIFF
--- a/docker/.gitignore
+++ b/docker/.gitignore
@@ -1,0 +1,1 @@
+docker-image

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,4 @@
+FROM centos:7
+RUN yum update -y \
+  && yum groupinstall -y "Development Tools" \
+  && yum install -y zlib-static glibc-static

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -1,0 +1,37 @@
+DOCKER_IMAGE_NAME := soapdenovo-trans
+DOCKER_IMAGE_TAG ?= latest
+
+help:
+	@ echo "build :  build $(DOCKER_IMAGE_NAME) binaries with a docker container"
+	@ echo "clean :  clean the binaries"
+
+.PHONY: docker-version
+docker-version:
+	docker version
+
+.PHONY: docker-image-check
+docker-image-check:
+	@if [ -f docker-image -a -z "$$(docker images -q $(DOCKER_IMAGE_NAME):$(DOCKER_IMAGE_TAG))" ]; then \
+		echo "docker-image file exists and docker image does not, removing check file"; \
+		rm docker-image; \
+	fi
+
+docker-image: Dockerfile
+	docker build -t $(DOCKER_IMAGE_NAME):$(DOCKER_IMAGE_TAG) .
+	@ touch $@
+
+build: docker-version docker-image-check docker-image
+	@echo "Executing 'make.sh' in docker"
+	docker run --rm \
+		-v $$(pwd)/..:/app \
+		-w /app \
+		$(DOCKER_IMAGE_NAME):$(DOCKER_IMAGE_TAG) \
+		bash make.sh
+
+clean: docker-version docker-image-check docker-image
+	@echo "Executing 'clean.sh' in docker"
+	docker run --rm \
+		-v $$(pwd)/..:/app \
+		-w /app \
+		$(DOCKER_IMAGE_NAME):$(DOCKER_IMAGE_TAG) \
+		bash clean.sh


### PR DESCRIPTION
Hi, I've added a `docker` directory which allows to build the binaries using a docker container. This may be useful to some users, e.g. facing problems with the build process https://github.com/aquaskyline/SOAPdenovo-Trans/issues/15 or requesting the binaries https://github.com/aquaskyline/SOAPdenovo-Trans/issues/10

* Use the docker to build binaries:
```sh
$ cd docker
$ make build
..
 # For the first run the output is quite verbose, because we need to build
 # the docker image to host the SOAPdenovo-Trans build process.
..
Successfully built acad049668bb
Successfully tagged soapdenovo-trans:latest
Executing 'make.sh' in docker
docker run --rm \
		-v $(pwd)/..:/app \
		-w /app \
		soapdenovo-trans:latest \
		bash make.sh
../SOAPdenovo-Trans-31mer cleaning done.
../SOAPdenovo-Trans-31mer compilation done.
../SOAPdenovo-Trans-127mer cleaning done.
../SOAPdenovo-Trans-127mer compilation done.
```

The binaries are placed in the main source directory.

* Clean the intermittent object files and remove the binaries
```sh
$ cd docker
$ make clean
..
Executing 'clean.sh' in docker
docker run --rm \
		-v $(pwd)/..:/app \
		-w /app \
		soapdenovo-trans:latest \
		bash clean.sh
../SOAPdenovo-Trans-31mer cleaning done.
../SOAPdenovo-Trans-127mer cleaning done.
```